### PR TITLE
Create Neon Arena shooter experience

### DIFF
--- a/game-app/index.html
+++ b/game-app/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Whack-a-Mole Arcade</title>
+    <title>Neon Arena - 2D FPS</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <header class="app-header">
-      <h1>Whack-a-Mole Arcade</h1>
-      <p class="tagline">Test your reflexes in this fast-paced browser game!</p>
+      <h1>Neon Arena</h1>
+      <p class="tagline">A fast-paced twin-stick FPS built in vanilla JavaScript.</p>
     </header>
 
-    <main class="game-container">
-      <section class="hud">
+    <main class="game-shell">
+      <aside class="hud">
         <div class="hud-item">
           <span class="label">Score</span>
           <span id="score" class="value">0</span>
@@ -23,32 +23,46 @@
           <span id="high-score" class="value">0</span>
         </div>
         <div class="hud-item">
-          <span class="label">Time</span>
-          <span id="timer" class="value">30</span>
+          <span class="label">Health</span>
+          <span id="health" class="value">3</span>
         </div>
-        <button id="start-button" class="primary-button">Start Game</button>
-      </section>
+        <button id="start-button" class="primary-button">Start Match</button>
+      </aside>
 
-      <section class="grid" aria-label="Whack-a-mole board">
-        <!-- Grid cells injected by JavaScript -->
+      <section class="canvas-wrapper">
+        <canvas id="game-canvas" width="960" height="600" aria-label="Neon Arena battleground"></canvas>
+        <div id="status" class="status-message">
+          <h2>Lock. Aim. Survive.</h2>
+          <p>
+            WASD to move • Aim with your mouse • Hold Left Click or tap Space to
+            fire. Keep the drones away as long as possible!
+          </p>
+        </div>
       </section>
 
       <section class="instructions">
         <h2>How to play</h2>
-        <ol>
-          <li>Press <strong>Start Game</strong> to begin a 30 second round.</li>
-          <li>Click the glowing mole as quickly as you can to score points.</li>
-          <li>Missing the mole or clicking an empty hole lowers your streak.</li>
-          <li>Keep an eye on the timer and chase a new personal best!</li>
-        </ol>
+        <ul>
+          <li>Press <strong>Start Match</strong> to spawn into the arena.</li>
+          <li>
+            Move with <strong>WASD</strong> or the arrow keys. Your agent always
+            aims at the cursor.
+          </li>
+          <li>
+            Hold <strong>Left Click</strong> or tap <strong>Space</strong> to
+            fire plasma bursts. Stay mobile for precision shots.
+          </li>
+          <li>
+            Colliding with a drone costs one health. Lose all three and the run
+            ends.
+          </li>
+          <li>Break your high score streak by staying alive and taking aim!</li>
+        </ul>
       </section>
     </main>
 
     <footer class="app-footer">
-      <p>
-        Built with vanilla HTML, CSS, and JavaScript. Refresh the page for a new
-        challenge!
-      </p>
+      <p>Built with HTML5 Canvas, CSS, and vanilla JavaScript.</p>
     </footer>
 
     <script src="script.js"></script>

--- a/game-app/script.js
+++ b/game-app/script.js
@@ -1,146 +1,377 @@
-const GRID_SIZE = 9;
-const ROUND_DURATION = 30; // seconds
-const MOLE_MIN_TIME = 500; // ms
-const MOLE_MAX_TIME = 1100; // ms
-
-const gridElement = document.querySelector('.grid');
-const scoreElement = document.getElementById('score');
-const highScoreElement = document.getElementById('high-score');
-const timerElement = document.getElementById('timer');
+const canvas = document.getElementById('game-canvas');
+const context = canvas.getContext('2d');
 const startButton = document.getElementById('start-button');
+const statusElement = document.getElementById('status');
+const scoreElement = document.getElementById('score');
+const healthElement = document.getElementById('health');
+const highScoreElement = document.getElementById('high-score');
 
-let score = 0;
-let highScore = Number(localStorage.getItem('wam-high-score')) || 0;
-let timeRemaining = ROUND_DURATION;
-let activeCellIndex = null;
-let isPlaying = false;
-let roundIntervalId = null;
-let moleTimeoutId = null;
-let streak = 0;
+const keysPressed = new Set();
+const pointer = { x: canvas.width / 2, y: canvas.height / 2 };
 
-highScoreElement.textContent = highScore;
+const PLAYER_RADIUS = 20;
+const BULLET_RADIUS = 6;
+const ENEMY_RADIUS = 24;
+const FIRE_RATE = 0.18; // seconds between shots
+const ENEMY_SPAWN_INTERVAL = 1.2; // seconds
 
-function createGrid() {
-  const fragment = document.createDocumentFragment();
+let animationFrameId = null;
+let lastTimestamp = 0;
+let spawnAccumulator = 0;
+let highScore = Number(localStorage.getItem('neon-arena-high-score')) || 0;
 
-  for (let index = 0; index < GRID_SIZE; index += 1) {
-    const cell = document.createElement('button');
-    cell.type = 'button';
-    cell.className = 'cell';
-    cell.setAttribute('aria-label', `Hole ${index + 1}`);
-    cell.dataset.index = index.toString();
+const gameState = {
+  active: false,
+  score: 0,
+  health: 3,
+  player: {
+    x: canvas.width / 2,
+    y: canvas.height / 2,
+    speed: 280,
+    angle: 0,
+  },
+  bullets: [],
+  enemies: [],
+  fireCooldown: 0,
+  isShooting: false,
+};
 
-    const mole = document.createElement('div');
-    mole.className = 'mole';
-
-    const streakBadge = document.createElement('div');
-    streakBadge.className = 'streak';
-    streakBadge.textContent = '';
-
-    cell.append(mole, streakBadge);
-    cell.addEventListener('click', handleCellClick);
-    fragment.appendChild(cell);
-  }
-
-  gridElement.appendChild(fragment);
-}
-
-function handleCellClick(event) {
-  if (!isPlaying) return;
-
-  const cell = event.currentTarget;
-  const clickedIndex = Number(cell.dataset.index);
-  const streakBadge = cell.querySelector('.streak');
-
-  if (clickedIndex === activeCellIndex) {
-    score += 1;
-    streak += 1;
-    scoreElement.textContent = score;
-    streakBadge.textContent = `🔥 Streak x${streak}`;
-    cell.classList.remove('active');
-    activeCellIndex = null;
-    triggerNextMole();
-  } else {
-    streak = 0;
-    streakBadge.textContent = 'Miss!';
-    setTimeout(() => {
-      streakBadge.textContent = '';
-    }, 600);
-  }
-}
-
-function triggerNextMole() {
-  clearTimeout(moleTimeoutId);
-
-  const nextDelay = getRandomInt(MOLE_MIN_TIME, MOLE_MAX_TIME);
-
-  moleTimeoutId = setTimeout(() => {
-    const cells = Array.from(gridElement.children);
-
-    if (activeCellIndex !== null) {
-      cells[activeCellIndex].classList.remove('active');
-      const badge = cells[activeCellIndex].querySelector('.streak');
-      badge.textContent = '';
-    }
-
-    const availableIndices = cells
-      .map((cell, index) => index)
-      .filter((index) => index !== activeCellIndex);
-
-    activeCellIndex =
-      availableIndices[Math.floor(Math.random() * availableIndices.length)];
-    cells[activeCellIndex].classList.add('active');
-  }, nextDelay);
-}
+highScoreElement.textContent = highScore.toString();
 
 function startGame() {
-  if (isPlaying) return;
+  if (gameState.active) return;
 
-  isPlaying = true;
+  resetGame();
+  gameState.active = true;
+  statusElement.classList.add('hidden');
   startButton.disabled = true;
-  score = 0;
-  streak = 0;
-  timeRemaining = ROUND_DURATION;
-  scoreElement.textContent = score;
-  timerElement.textContent = timeRemaining;
-
-  triggerNextMole();
-
-  roundIntervalId = setInterval(() => {
-    timeRemaining -= 1;
-    timerElement.textContent = timeRemaining;
-
-    if (timeRemaining <= 0) {
-      endGame();
-    }
-  }, 1000);
+  lastTimestamp = performance.now();
+  animationFrameId = requestAnimationFrame(loop);
 }
 
-function endGame() {
-  clearInterval(roundIntervalId);
-  clearTimeout(moleTimeoutId);
+function resetGame() {
+  gameState.score = 0;
+  gameState.health = 3;
+  gameState.player.x = canvas.width / 2;
+  gameState.player.y = canvas.height / 2;
+  gameState.player.angle = 0;
+  gameState.bullets.length = 0;
+  gameState.enemies.length = 0;
+  gameState.fireCooldown = 0;
+  spawnAccumulator = 0;
+  updateHUD();
+}
 
-  const cells = Array.from(gridElement.children);
-  cells.forEach((cell) => {
-    cell.classList.remove('active');
-    const badge = cell.querySelector('.streak');
-    badge.textContent = '';
-  });
+function endGame(message) {
+  gameState.active = false;
+  cancelAnimationFrame(animationFrameId);
+  startButton.disabled = false;
+  statusElement.innerHTML = `<h2>${message}</h2><p>Press Start Match to try again.</p>`;
+  statusElement.classList.remove('hidden');
 
-  if (score > highScore) {
-    highScore = score;
-    localStorage.setItem('wam-high-score', highScore);
-    highScoreElement.textContent = highScore;
+  if (gameState.score > highScore) {
+    highScore = gameState.score;
+    highScoreElement.textContent = highScore.toString();
+    localStorage.setItem('neon-arena-high-score', String(highScore));
+  }
+}
+
+function loop(timestamp) {
+  const delta = (timestamp - lastTimestamp) / 1000;
+  lastTimestamp = timestamp;
+
+  update(delta);
+  render();
+
+  if (gameState.active) {
+    animationFrameId = requestAnimationFrame(loop);
+  }
+}
+
+function update(delta) {
+  handleMovement(delta);
+  handleShooting(delta);
+  updateBullets(delta);
+  updateEnemies(delta);
+  detectCollisions();
+}
+
+function handleMovement(delta) {
+  const horizontal = (keysPressed.has('d') || keysPressed.has('ArrowRight') ? 1 : 0) -
+    (keysPressed.has('a') || keysPressed.has('ArrowLeft') ? 1 : 0);
+  const vertical = (keysPressed.has('s') || keysPressed.has('ArrowDown') ? 1 : 0) -
+    (keysPressed.has('w') || keysPressed.has('ArrowUp') ? 1 : 0);
+
+  const magnitude = Math.hypot(horizontal, vertical);
+  if (magnitude > 0) {
+    const normalizedX = horizontal / magnitude;
+    const normalizedY = vertical / magnitude;
+    gameState.player.x += normalizedX * gameState.player.speed * delta;
+    gameState.player.y += normalizedY * gameState.player.speed * delta;
   }
 
-  activeCellIndex = null;
-  isPlaying = false;
-  startButton.disabled = false;
+  gameState.player.x = Math.max(PLAYER_RADIUS, Math.min(canvas.width - PLAYER_RADIUS, gameState.player.x));
+  gameState.player.y = Math.max(PLAYER_RADIUS, Math.min(canvas.height - PLAYER_RADIUS, gameState.player.y));
+  gameState.player.angle = Math.atan2(pointer.y - gameState.player.y, pointer.x - gameState.player.x);
 }
 
-function getRandomInt(min, max) {
-  return Math.floor(Math.random() * (max - min + 1) + min);
+function handleShooting(delta) {
+  gameState.fireCooldown = Math.max(0, gameState.fireCooldown - delta);
+  if (!gameState.isShooting || gameState.fireCooldown > 0) return;
+
+  spawnBullet();
+  gameState.fireCooldown = FIRE_RATE;
 }
 
-createGrid();
+function spawnBullet() {
+  const bulletSpeed = 620;
+  gameState.bullets.push({
+    x: gameState.player.x + Math.cos(gameState.player.angle) * (PLAYER_RADIUS + 6),
+    y: gameState.player.y + Math.sin(gameState.player.angle) * (PLAYER_RADIUS + 6),
+    angle: gameState.player.angle,
+    speed: bulletSpeed,
+    lifetime: 0,
+  });
+}
+
+function updateBullets(delta) {
+  for (let index = gameState.bullets.length - 1; index >= 0; index -= 1) {
+    const bullet = gameState.bullets[index];
+    bullet.x += Math.cos(bullet.angle) * bullet.speed * delta;
+    bullet.y += Math.sin(bullet.angle) * bullet.speed * delta;
+    bullet.lifetime += delta;
+
+    if (
+      bullet.x < -BULLET_RADIUS ||
+      bullet.x > canvas.width + BULLET_RADIUS ||
+      bullet.y < -BULLET_RADIUS ||
+      bullet.y > canvas.height + BULLET_RADIUS ||
+      bullet.lifetime > 2.2
+    ) {
+      gameState.bullets.splice(index, 1);
+    }
+  }
+}
+
+function updateEnemies(delta) {
+  spawnAccumulator += delta;
+  if (spawnAccumulator >= ENEMY_SPAWN_INTERVAL) {
+    spawnAccumulator -= ENEMY_SPAWN_INTERVAL;
+    spawnEnemy();
+  }
+
+  for (let index = gameState.enemies.length - 1; index >= 0; index -= 1) {
+    const enemy = gameState.enemies[index];
+    const angleToPlayer = Math.atan2(gameState.player.y - enemy.y, gameState.player.x - enemy.x);
+    enemy.x += Math.cos(angleToPlayer) * enemy.speed * delta;
+    enemy.y += Math.sin(angleToPlayer) * enemy.speed * delta;
+    enemy.rotation = angleToPlayer;
+  }
+}
+
+function spawnEnemy() {
+  const perimeter = Math.random() * (canvas.width * 2 + canvas.height * 2);
+  let x;
+  let y;
+
+  if (perimeter < canvas.width) {
+    x = perimeter;
+    y = -ENEMY_RADIUS;
+  } else if (perimeter < canvas.width + canvas.height) {
+    x = canvas.width + ENEMY_RADIUS;
+    y = perimeter - canvas.width;
+  } else if (perimeter < canvas.width * 2 + canvas.height) {
+    x = perimeter - (canvas.width + canvas.height);
+    y = canvas.height + ENEMY_RADIUS;
+  } else {
+    x = -ENEMY_RADIUS;
+    y = perimeter - (canvas.width * 2 + canvas.height);
+  }
+
+  const speed = 80 + Math.random() * 70 + gameState.score * 0.2;
+  gameState.enemies.push({ x, y, speed, rotation: 0, health: 1 });
+}
+
+function detectCollisions() {
+  // Bullets hitting enemies
+  for (let bulletIndex = gameState.bullets.length - 1; bulletIndex >= 0; bulletIndex -= 1) {
+    const bullet = gameState.bullets[bulletIndex];
+
+    for (let enemyIndex = gameState.enemies.length - 1; enemyIndex >= 0; enemyIndex -= 1) {
+      const enemy = gameState.enemies[enemyIndex];
+      if (circleIntersect(bullet.x, bullet.y, BULLET_RADIUS, enemy.x, enemy.y, ENEMY_RADIUS)) {
+        gameState.bullets.splice(bulletIndex, 1);
+        gameState.enemies.splice(enemyIndex, 1);
+        gameState.score += 10;
+        updateHUD();
+        break;
+      }
+    }
+  }
+
+  // Enemies hitting the player
+  for (let index = gameState.enemies.length - 1; index >= 0; index -= 1) {
+    const enemy = gameState.enemies[index];
+    if (circleIntersect(enemy.x, enemy.y, ENEMY_RADIUS - 6, gameState.player.x, gameState.player.y, PLAYER_RADIUS)) {
+      gameState.enemies.splice(index, 1);
+      gameState.health -= 1;
+      updateHUD();
+      if (gameState.health <= 0) {
+        endGame('Mission Failed');
+      }
+    }
+  }
+}
+
+function circleIntersect(x1, y1, r1, x2, y2, r2) {
+  const distance = Math.hypot(x2 - x1, y2 - y1);
+  return distance < r1 + r2;
+}
+
+function render() {
+  context.clearRect(0, 0, canvas.width, canvas.height);
+  drawBackground();
+  drawPlayer();
+  drawBullets();
+  drawEnemies();
+  drawPointer();
+}
+
+function drawBackground() {
+  const gradient = context.createRadialGradient(
+    gameState.player.x,
+    gameState.player.y,
+    40,
+    canvas.width / 2,
+    canvas.height / 2,
+    Math.max(canvas.width, canvas.height)
+  );
+  gradient.addColorStop(0, 'rgba(14, 165, 233, 0.15)');
+  gradient.addColorStop(1, 'rgba(15, 23, 42, 0.85)');
+
+  context.fillStyle = gradient;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  context.strokeStyle = 'rgba(148, 163, 184, 0.2)';
+  context.lineWidth = 1;
+  const gridSize = 60;
+  for (let x = gridSize; x < canvas.width; x += gridSize) {
+    context.beginPath();
+    context.moveTo(x, 0);
+    context.lineTo(x, canvas.height);
+    context.stroke();
+  }
+  for (let y = gridSize; y < canvas.height; y += gridSize) {
+    context.beginPath();
+    context.moveTo(0, y);
+    context.lineTo(canvas.width, y);
+    context.stroke();
+  }
+}
+
+function drawPlayer() {
+  context.save();
+  context.translate(gameState.player.x, gameState.player.y);
+  context.rotate(gameState.player.angle);
+
+  context.fillStyle = '#38bdf8';
+  context.beginPath();
+  context.arc(0, 0, PLAYER_RADIUS, 0, Math.PI * 2);
+  context.fill();
+
+  context.fillStyle = '#0f172a';
+  context.fillRect(0, -6, PLAYER_RADIUS + 14, 12);
+
+  context.restore();
+}
+
+function drawBullets() {
+  context.fillStyle = '#facc15';
+  gameState.bullets.forEach((bullet) => {
+    context.beginPath();
+    context.arc(bullet.x, bullet.y, BULLET_RADIUS, 0, Math.PI * 2);
+    context.fill();
+  });
+}
+
+function drawEnemies() {
+  gameState.enemies.forEach((enemy) => {
+    context.save();
+    context.translate(enemy.x, enemy.y);
+    context.rotate(enemy.rotation);
+
+    context.fillStyle = '#f97316';
+    context.beginPath();
+    context.arc(0, 0, ENEMY_RADIUS, 0, Math.PI * 2);
+    context.fill();
+
+    context.fillStyle = '#1f2937';
+    context.fillRect(-ENEMY_RADIUS / 2, -6, ENEMY_RADIUS, 12);
+    context.restore();
+  });
+}
+
+function drawPointer() {
+  context.save();
+  context.strokeStyle = 'rgba(248, 250, 252, 0.8)';
+  context.lineWidth = 2;
+  context.beginPath();
+  context.moveTo(pointer.x - 12, pointer.y);
+  context.lineTo(pointer.x + 12, pointer.y);
+  context.moveTo(pointer.x, pointer.y - 12);
+  context.lineTo(pointer.x, pointer.y + 12);
+  context.stroke();
+  context.restore();
+}
+
+function updateHUD() {
+  scoreElement.textContent = gameState.score.toString();
+  healthElement.textContent = gameState.health.toString();
+}
+
+function handleKeydown(event) {
+  if (event.repeat) return;
+  if (event.code === 'Space') {
+    gameState.isShooting = true;
+    event.preventDefault();
+  }
+  keysPressed.add(event.key);
+}
+
+function handleKeyup(event) {
+  keysPressed.delete(event.key);
+  if (event.code === 'Space') {
+    gameState.isShooting = false;
+  }
+}
+
+function handleMouseMove(event) {
+  const rect = canvas.getBoundingClientRect();
+  pointer.x = (event.clientX - rect.left) * (canvas.width / rect.width);
+  pointer.y = (event.clientY - rect.top) * (canvas.height / rect.height);
+}
+
+function handleMouseDown(event) {
+  if (event.button !== 0) return;
+  gameState.isShooting = true;
+}
+
+function handleMouseUp(event) {
+  if (event.button !== 0) return;
+  gameState.isShooting = false;
+}
+
+function handleLeave() {
+  gameState.isShooting = false;
+}
+
 startButton.addEventListener('click', startGame);
+document.addEventListener('keydown', handleKeydown);
+document.addEventListener('keyup', handleKeyup);
+canvas.addEventListener('mousemove', handleMouseMove);
+canvas.addEventListener('mousedown', handleMouseDown);
+canvas.addEventListener('mouseup', handleMouseUp);
+canvas.addEventListener('mouseleave', handleLeave);
+
+updateHUD();
+render();

--- a/game-app/style.css
+++ b/game-app/style.css
@@ -1,7 +1,8 @@
 :root {
-  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  color: #0f172a;
-  background-color: #f8fafc;
+  color-scheme: light dark;
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #020617;
+  color: #e2e8f0;
 }
 
 * {
@@ -14,13 +15,14 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: radial-gradient(circle at top, #f0f4ff, #f8fafc 40%, #e2e8f0);
+  background: radial-gradient(circle at top, rgba(30, 64, 175, 0.4), #020617 55%);
 }
 
 .app-header,
 .app-footer {
   text-align: center;
-  padding: 1.5rem 1rem;
+  padding: 1.75rem 1rem 1rem;
+  max-width: 960px;
 }
 
 .app-header {
@@ -28,170 +30,189 @@ body {
 }
 
 .app-header h1 {
-  margin-bottom: 0.5rem;
-  font-size: clamp(2.25rem, 4vw, 3rem);
-  color: #1e293b;
+  margin: 0 0 0.35rem;
+  font-size: clamp(2.5rem, 6vw, 3.5rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #38bdf8;
+  text-shadow: 0 0 25px rgba(59, 130, 246, 0.55);
 }
 
 .tagline {
   margin: 0;
   font-size: 1.1rem;
-  color: #475569;
+  color: rgba(226, 232, 240, 0.8);
 }
 
-.game-container {
+.game-shell {
+  width: min(95vw, 1100px);
   display: grid;
-  grid-template-columns: minmax(0, 400px);
-  gap: 1.5rem;
-  align-items: center;
-  width: min(90vw, 700px);
-  margin-bottom: 2rem;
+  grid-template-columns: minmax(0, 260px) minmax(0, 1fr);
+  gap: 1.75rem;
+  align-items: start;
+  padding: 2rem 1rem 3rem;
 }
 
 .hud {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background: rgba(255, 255, 255, 0.8);
-  border-radius: 1rem;
-  padding: 1rem 1.5rem;
-  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.12);
-  gap: 1rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.65);
 }
 
 .hud-item {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  min-width: 90px;
+  gap: 0.25rem;
 }
 
 .label {
   text-transform: uppercase;
-  font-size: 0.8rem;
-  letter-spacing: 0.1rem;
-  color: #64748b;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
 }
 
 .value {
+  font-size: 2.4rem;
   font-weight: 700;
-  font-size: 1.75rem;
-  color: #1d4ed8;
+  color: #facc15;
+  text-shadow: 0 0 12px rgba(250, 204, 21, 0.55);
 }
 
 .primary-button {
   border: none;
-  background: linear-gradient(135deg, #2563eb, #6366f1);
-  color: #fff;
-  font-weight: 600;
-  padding: 0.75rem 1.5rem;
-  border-radius: 999px;
   cursor: pointer;
-  box-shadow: 0 10px 25px rgba(79, 70, 229, 0.3);
+  padding: 0.9rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #7c3aed, #2563eb);
+  color: #f8fafc;
+  box-shadow: 0 15px 40px rgba(59, 130, 246, 0.45);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .primary-button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 15px 30px rgba(79, 70, 229, 0.35);
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 20px 55px rgba(59, 130, 246, 0.6);
 }
 
 .primary-button:disabled {
-  background: #94a3b8;
-  cursor: not-allowed;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.8), rgba(71, 85, 105, 0.9));
   box-shadow: none;
+  cursor: not-allowed;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-  background: rgba(255, 255, 255, 0.75);
-  padding: 1.5rem;
-  border-radius: 1.5rem;
-  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.15);
-}
-
-.cell {
+.canvas-wrapper {
   position: relative;
-  aspect-ratio: 1 / 1;
-  border-radius: 20px;
-  background: linear-gradient(145deg, #e2e8f0, #f8fafc);
-  box-shadow: inset 10px 10px 15px rgba(148, 163, 184, 0.35),
-    inset -10px -10px 15px rgba(255, 255, 255, 0.8);
-  cursor: pointer;
+  border-radius: 1.5rem;
   overflow: hidden;
-  transition: transform 0.15s ease;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 25px 65px rgba(14, 116, 144, 0.5);
 }
 
-.cell:active {
-  transform: scale(0.95);
+#game-canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: #0f172a;
 }
 
-.cell::after {
-  content: '';
+.status-message {
   position: absolute;
   inset: 0;
-  border-radius: inherit;
-  background: radial-gradient(circle, rgba(99, 102, 241, 0.4), transparent 70%);
-  opacity: 0;
-  transition: opacity 0.2s ease;
-}
-
-.cell.active::after {
-  opacity: 1;
-}
-
-.cell .mole {
-  position: absolute;
-  bottom: -15%;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 70%;
-  height: 70%;
-  border-radius: 50% 50% 40% 40%;
-  background: linear-gradient(145deg, #f97316, #ea580c);
-  box-shadow: 0 5px 15px rgba(234, 88, 12, 0.45);
-  opacity: 0;
-  transition: opacity 0.15s ease;
-}
-
-.cell.active .mole {
-  opacity: 1;
-}
-
-.streak {
-  font-size: 0.85rem;
-  color: #0f172a;
-  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
+  padding: 2rem;
+  background: rgba(15, 23, 42, 0.72);
+  color: #e2e8f0;
+  transition: opacity 0.3s ease;
+}
+
+.status-message.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.status-message h2 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  color: #f97316;
+  text-shadow: 0 0 15px rgba(249, 115, 22, 0.5);
+}
+
+.status-message p {
+  margin: 0;
+  max-width: 360px;
+  line-height: 1.6;
 }
 
 .instructions {
-  background: rgba(255, 255, 255, 0.75);
-  padding: 1.5rem;
+  grid-column: 1 / -1;
+  background: rgba(15, 23, 42, 0.55);
   border-radius: 1.25rem;
-  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.12);
-  color: #475569;
+  padding: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 20px 45px rgba(15, 118, 110, 0.35);
 }
 
 .instructions h2 {
   margin-top: 0;
-  color: #1e293b;
+  color: #38bdf8;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 
-.instructions ol {
-  padding-left: 1.25rem;
-  margin-bottom: 0;
+.instructions ul {
+  margin: 0;
+  padding-left: 1.3rem;
+  line-height: 1.7;
+  color: rgba(226, 232, 240, 0.85);
 }
 
-@media (max-width: 600px) {
+.app-footer {
+  margin-bottom: 2rem;
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 960px) {
+  .game-shell {
+    grid-template-columns: 1fr;
+  }
+
   .hud {
+    flex-direction: row;
+    flex-wrap: wrap;
     justify-content: center;
+    gap: 1.5rem;
   }
 
   .hud-item {
-    flex: 1 1 30%;
+    min-width: 120px;
+    text-align: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .game-shell {
+    padding: 1.5rem 1rem 2.5rem;
+  }
+
+  .value {
+    font-size: 2rem;
+  }
+
+  .instructions {
+    padding: 1.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the whack-a-mole markup with a neon-themed arena shooter layout and updated instructions
- implement a canvas-driven twin-stick FPS game loop with movement, shooting, enemy spawning, and score tracking
- restyle the app with dark neon HUD, responsive layout, and overlay status messaging

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dbdd1c63c48327a69920e5f01aa672